### PR TITLE
Made writeImageExact more general (again) and fixed exports

### DIFF
--- a/hip.cabal
+++ b/hip.cabal
@@ -1,5 +1,5 @@
 Name:              hip
-Version:           1.5.1.0
+Version:           1.5.1.1
 License:           BSD3
 License-File:      LICENSE
 Author:            Alexey Kuleshevich

--- a/src/Graphics/Image/IO.hs
+++ b/src/Graphics/Image/IO.hs
@@ -146,13 +146,13 @@ writeImage path = BL.writeFile path . encode format [] . exchange VS where
 -- options. Precision and color space, that an image will be written as, is decided
 -- from image's type. Attempt to write image file in a format that does not
 -- support color space and precision combination will result in a compile error.
-writeImageExact :: Writable (Image arr cs e) format =>
+writeImageExact :: Writable img format =>
                    format
                    -- ^ A file format that an image should be saved in. See
                    -- <#g:4 Supported Image Formats>
                 -> [SaveOption format] -- ^ A list of format specific options.
                 -> FilePath -- ^ Location where an image should be written.
-                -> (Image arr cs e) -- ^ An image to write. Can be a list of images in case
+                -> img -- ^ An image to write. Can be a list of images in case
                        -- of formats supporting animation.
                 -> IO ()
 writeImageExact format opts path = BL.writeFile path . encode format opts

--- a/src/Graphics/Image/IO/Formats.hs
+++ b/src/Graphics/Image/IO/Formats.hs
@@ -17,6 +17,7 @@ module Graphics.Image.IO.Formats (
   module Graphics.Image.IO.Formats.Netpbm,
   InputFormat(..), OutputFormat(..),
   Readable(..), Writable(..), ImageFormat(..),
+  SaveOption(..)
   ) where
 
 import Graphics.Image.ColorSpace


### PR DESCRIPTION
`SaveOptions` needed to be exported explicitly here so that things like
`GIFsLooping` could be referenced.

maybe it should be larger version bump because of the api change to `writeImageExact`? (i'm basically just reverting it to what it used to be; maybe there was a reason to make it specialised)