### PR TITLE
Fixed comment describing backpermute

### DIFF
--- a/src/Graphics/Image/Interface.hs
+++ b/src/Graphics/Image/Interface.hs
@@ -250,8 +250,8 @@ class (VG.Vector (Vector arr) (Pixel cs e),
   -- | Backwards permutation of an image.
   backpermute :: (Int, Int) -- ^ Dimensions of a result image.
               -> ((Int, Int) -> (Int, Int))
-                 -- ^ Function that maps an index of a source image to an index
-                 -- of a result image.
+                 -- ^ Function that maps an index of a result image to an index
+                 -- of a source image.
               -> Image arr cs e -- ^ Source image.
               -> Image arr cs e -- ^ Result image.
 


### PR DESCRIPTION
Backpermute means that the function takes an index from the *result* image, and yields an index in the *source* image. See [this repa function](https://hackage.haskell.org/package/repa-3.4.1.3/docs/Data-Array-Repa.html#v:backpermute) for example.