### PR TITLE
Port `eqTol` and `and`

### DIFF
--- a/src/Graphics/Image.hs
+++ b/src/Graphics/Image.hs
@@ -126,9 +126,10 @@ module Graphics.Image
   , maximum
   , minimum
   , normalize
-  -- , eqTol
+  , eqTol
   ) where
 
+import qualified Data.Foldable             as F
 import qualified Data.Massiv.Array         as A
 import           Graphics.Pixel.ColorSpace
 import           Graphics.Image.Internal   as I
@@ -137,6 +138,7 @@ import           Graphics.Image.Processing as IP
 import           Prelude                   as P hiding (map, maximum, minimum,
                                                  product, sum, traverse,
                                                  zipWith, zipWith3)
+
 -- import Graphics.Image.Types as IP
 
 -- import Graphics.Image.Processing as IP
@@ -288,13 +290,23 @@ normalize img =
     !iMin = minVal img
 {-# INLINE normalize #-}
 
--- -- | Check weather two images are equal within a tolerance. Useful for comparing
--- -- images with `Float` or `Double` precision.
--- eqTol
---   :: (ColorModel cs e, Ord e) =>
---      e -> Image cs e -> Image cs e -> Bool
--- eqTol !tol !img1 = IP.and . thresholdWith2 (eqTolPx tol) img1
--- {-# INLINE eqTol #-}
+-- | Check weather two images are equal within a tolerance. Useful for comparing
+-- images with `Float` or `Double` precision.
+--
+-- >>> eqTol 0.99 (makeImage (Sz2 2 2) (const 0) :: Image Model.Y Float) (makeImage (Sz2 2 2) (const 1))
+-- False
+--
+-- >>> eqTol 1 (makeImage (Sz2 2 2) (const 0) :: Image Model.Y Float) (makeImage (Sz2 2 2) (const 1))
+-- True
+eqTol
+  :: (ColorModel cs e, Ord e) =>
+     e -> Image cs e -> Image cs e -> Bool
+eqTol !tol !img1 =
+  IP.and . thresholdWith2 thresholdPixel img1
+  where
+    thresholdPixel pixelA pixelB = F.foldl' (||) False (thresholdComponent <$> pixelA <*> pixelB)
+    thresholdComponent compA compB = abs (compA - compB) <= tol
+{-# INLINE eqTol #-}
 
 
 

--- a/src/Graphics/Image.hs
+++ b/src/Graphics/Image.hs
@@ -304,7 +304,7 @@ eqTol
 eqTol !tol !img1 =
   IP.and . thresholdWith2 thresholdPixel img1
   where
-    thresholdPixel pixelA pixelB = F.foldl' (||) False (thresholdComponent <$> pixelA <*> pixelB)
+    thresholdPixel pixelA pixelB = F.foldl' (&&) True (thresholdComponent <$> pixelA <*> pixelB)
     thresholdComponent compA compB = abs (compA - compB) <= tol
 {-# INLINE eqTol #-}
 

--- a/src/Graphics/Image/Processing/Binary.hs
+++ b/src/Graphics/Image/Processing/Binary.hs
@@ -39,7 +39,7 @@ module Graphics.Image.Processing.Binary
   , (.||.)
   -- * Bitwise operations
   -- , or
-  -- , and
+  , and
   , invert
   , disjunction
   , conjunction
@@ -60,6 +60,7 @@ import Graphics.Image.Internal as I
 import Graphics.Image.Processing.Convolution
 import Prelude as P hiding (and, or)
 import Graphics.Color.Algebra.Binary
+import Data.Monoid (Product(..))
 
 infix  4  .==., ./=., .<., .<=., .>=., .>., !==!, !/=!, !<!, !<=!, !>=!, !>!
 -- infixr 3  .&&., !&&!
@@ -227,10 +228,10 @@ conjunction = I.map (pure . F.foldl' (.&.) one)
 -- or = isOn . foldSemi (.|.) off
 -- {-# INLINE or #-}
 
--- -- | Conjunction of all pixels in a Binary image
--- and :: Image Model.Y Bit -> Bool
--- and = isOn . foldl (.&.) on
--- {-# INLINE and #-}
+-- | Conjunction of all pixels in a Binary image
+and :: Image Model.Y Bit -> Bool
+and =  (==1) . getProduct . I.foldMono Product
+{-# INLINE and #-}
 
 
 {- $morphology In order to demonstrate how morphological operations work, a

--- a/src/Graphics/Image/Processing/Binary.hs
+++ b/src/Graphics/Image/Processing/Binary.hs
@@ -60,7 +60,7 @@ import Graphics.Image.Internal as I
 import Graphics.Image.Processing.Convolution
 import Prelude as P hiding (and, or)
 import Graphics.Color.Algebra.Binary
-import Data.Monoid (Product(..))
+import Data.Monoid (All(..))
 
 infix  4  .==., ./=., .<., .<=., .>=., .>., !==!, !/=!, !<!, !<=!, !>=!, !>!
 -- infixr 3  .&&., !&&!
@@ -230,7 +230,7 @@ conjunction = I.map (pure . F.foldl' (.&.) one)
 
 -- | Conjunction of all pixels in a Binary image
 and :: Image Model.Y Bit -> Bool
-and =  (==1) . getProduct . I.foldMono Product
+and =  getAll . I.foldMono (All . (== pure one))
 {-# INLINE and #-}
 
 


### PR DESCRIPTION
As a first attempt to port something small to hip 2.0 I ported the
commented out function `Graphics.Image.eqTol` which required porting
`Graphics.Image.Processing.Binary.and`.