### PR TITLE
Provide more simplifier ticks for GHC 9.6 and 9.8

### DIFF
--- a/hip.cabal
+++ b/hip.cabal
@@ -108,6 +108,8 @@ Library
                  , Graphics.Image.Utils
                  , Graphics.Image.IO.Formats.Netpbm
   GHC-Options:     -Wall
+  if impl(ghc >=9.6 && <9.9)
+    GHC-Options:   -fsimpl-tick-factor=200
   if flag(disable-chart)
     CPP-Options: -DDISABLE_CHART
   if os(windows)


### PR DESCRIPTION
This PR is for the `hip-1.x` branch.

The module `Graphics.Image.Types` failed to build with GHC 9.6.3 and GHC 9.8.1. No problems with GHC 9.4. I did not test GHC 9.10.

The error was "Simplifier ticks exhausted. Total ticks: 4241"

A tick factor of 200 was enough to let it build.

I found this build error when trying to use hip with nixpkgs (https://github.com/NixOS/nixpkgs/pull/276275).